### PR TITLE
Fix compilation against PG11

### DIFF
--- a/triggers/common.h
+++ b/triggers/common.h
@@ -1,3 +1,8 @@
+#if PG_VERSION_NUM < 100000
+/* from src/include/access/tupdesc.h, introduced in 2cd708452 */
+#define TupleDescAttr(tupdesc, i) ((tupdesc)->attrs[(i)])
+#endif
+
 enum PgqFields {
 	EV_TYPE = 0,
 	EV_DATA,

--- a/triggers/jsontriga.c
+++ b/triggers/jsontriga.c
@@ -164,7 +164,7 @@ static void pgq_jsonenc_row(PgqTriggerEvent *ev, HeapTuple row, StringInfo buf)
 	appendStringInfoChar(buf, '{');
 	for (i = 0; i < tg->tg_relation->rd_att->natts; i++) {
 		/* Skip dropped columns */
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		attkind_idx++;
@@ -183,7 +183,7 @@ static void pgq_jsonenc_row(PgqTriggerEvent *ev, HeapTuple row, StringInfo buf)
 		appendStringInfoChar(buf, ':');
 
 		/* quote column value */
-		col_type = tupdesc->attrs[i]->atttypid;
+		col_type = TupleDescAttr(tupdesc, i)->atttypid;
 		col_datum = SPI_getbinval(row, tupdesc, i + 1, &isnull);
 		col_value = NULL;
 		if (isnull) {

--- a/triggers/logutriga.c
+++ b/triggers/logutriga.c
@@ -43,7 +43,7 @@ void pgq_urlenc_row(PgqTriggerEvent *ev, HeapTuple row, StringInfo buf)
 
 	for (i = 0; i < tg->tg_relation->rd_att->natts; i++) {
 		/* Skip dropped columns */
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		attkind_idx++;

--- a/triggers/makesql.c
+++ b/triggers/makesql.c
@@ -71,7 +71,7 @@ static void process_insert(PgqTriggerEvent *ev, StringInfo sql)
 		char *col_ident;
 
 		/* Skip dropped columns */
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		/* Check if allowed by colstring */
@@ -103,7 +103,7 @@ static void process_insert(PgqTriggerEvent *ev, StringInfo sql)
 		char *col_value;
 
 		/* Skip dropped columns */
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		/* Check if allowed by colstring */
@@ -154,7 +154,7 @@ static int process_update(PgqTriggerEvent *ev, StringInfo sql)
 		/*
 		 * Ignore dropped columns
 		 */
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		attkind_idx++;
@@ -240,7 +240,7 @@ static int process_update(PgqTriggerEvent *ev, StringInfo sql)
 			return 0;
 
 		for (i = 0, attkind_idx = -1; i < tupdesc->natts; i++) {
-			if (tupdesc->attrs[i]->attisdropped)
+			if (TupleDescAttr(tupdesc, i)->attisdropped)
 				continue;
 
 			attkind_idx++;
@@ -259,7 +259,7 @@ static int process_update(PgqTriggerEvent *ev, StringInfo sql)
 		/*
 		 * Ignore dropped columns
 		 */
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		attkind_idx++;
@@ -291,7 +291,7 @@ static void process_delete(PgqTriggerEvent *ev, StringInfo sql)
 	int attkind_idx;
 
 	for (i = 0, attkind_idx = -1; i < tupdesc->natts; i++) {
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 
 		attkind_idx++;
@@ -323,7 +323,7 @@ int pgqtriga_make_sql(PgqTriggerEvent *ev, StringInfo sql)
 	 * Count number of active columns
 	 */
 	for (i = 0, attcnt = 0; i < tupdesc->natts; i++) {
-		if (tupdesc->attrs[i]->attisdropped)
+		if (TupleDescAttr(tupdesc, i)->attisdropped)
 			continue;
 		attcnt++;
 	}


### PR DESCRIPTION
tupdesc is an opaque structure now, it needs to be accessed through
TupleDescAttr(tupdesc, i).

AllocSetContextCreate is now a 3-argument macro.

Close #2.