### PR TITLE
Required fixes for PostgreSQL 12

### DIFF
--- a/expected/trigger_types.out
+++ b/expected/trigger_types.out
@@ -3,6 +3,7 @@ set client_min_messages = 'warning';
 set DateStyle = 'ISO, YMD';
 set timezone = 'UTC';
 set bytea_output = 'hex';
+set extra_float_digits = 0;
 \set ECHO none
 select typetest('text', null);
 WARNING:  insert_event(q=[jsontriga], t=[{"op":"INSERT","table":["public","ttest"],"pkey":[]}], d=[{"nr":1,"val":null,"arr":"{NULL,NULL}"}])

--- a/sql/trigger_types.sql
+++ b/sql/trigger_types.sql
@@ -48,6 +48,8 @@ begin
     */
 
     execute 'drop table ttest';
+exception when invalid_text_representation then
+    raise exception 'invalid input syntax for type %: "%"', typ, val;
 end;
 $$ language plpgsql;
 

--- a/sql/trigger_types.sql
+++ b/sql/trigger_types.sql
@@ -3,6 +3,7 @@ set client_min_messages = 'warning';
 set DateStyle = 'ISO, YMD';
 set timezone = 'UTC';
 set bytea_output = 'hex';
+set extra_float_digits = 0;
 
 \set ECHO none
 

--- a/triggers/common.c
+++ b/triggers/common.c
@@ -902,7 +902,9 @@ int pgq_is_interesting_change(PgqTriggerEvent *ev, TriggerData *tg)
 			 * attributes and do string comparison.
 			 */
 			if (OidIsValid(opr_oid)) {
-				if (DatumGetBool(FunctionCall2(opr_finfo_p, old_value, new_value)))
+				if (DatumGetBool(FunctionCall2Coll(opr_finfo_p,
+								   TupleDescAttr(tupdesc, i)->attcollation,
+								   old_value, new_value)))
 					continue;
 			} else {
 				char *old_strval = SPI_getvalue(old_row, tupdesc, i + 1);

--- a/triggers/makesql.c
+++ b/triggers/makesql.c
@@ -196,7 +196,9 @@ static int process_update(PgqTriggerEvent *ev, StringInfo sql)
 			 * attributes and do string comparison.
 			 */
 			if (OidIsValid(opr_oid)) {
-				if (DatumGetBool(FunctionCall2(opr_finfo_p, old_value, new_value)))
+				if (DatumGetBool(FunctionCall2Coll(opr_finfo_p,
+								   TupleDescAttr(tupdesc, i)->attcollation,
+								   old_value, new_value)))
 					continue;
 			} else {
 				char *old_strval = SPI_getvalue(old_row, tupdesc, i + 1);


### PR DESCRIPTION
These are some fixes that are required to make pgq work with PostgreSQL 12. Tests pass cleanly after this, and it's backward compatible.